### PR TITLE
Reintroduce droprate modifiers from 5.3 code

### DIFF
--- a/PlayerHeads-api/dependency-reduced-pom.xml
+++ b/PlayerHeads-api/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>PlayerHeads</artifactId>
     <groupId>org.shininet.bukkit</groupId>
-    <version>5.2.15-SNAPSHOT</version>
+    <version>5.2.16-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>PlayerHeads-api</artifactId>

--- a/PlayerHeads-api/pom.xml
+++ b/PlayerHeads-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.shininet.bukkit</groupId>
         <artifactId>PlayerHeads</artifactId>
-        <version>5.2.15-SNAPSHOT</version>
+        <version>5.2.16-SNAPSHOT</version>
     </parent>
     <artifactId>PlayerHeads-api</artifactId>
     <packaging>jar</packaging>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.shininet.bukkit</groupId>
             <artifactId>PlayerHeads-base-api</artifactId>
-            <version>5.2.15-SNAPSHOT</version>
+            <version>5.2.16-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.shininet.bukkit</groupId>

--- a/PlayerHeads-base-api/pom.xml
+++ b/PlayerHeads-base-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.shininet.bukkit</groupId>
         <artifactId>PlayerHeads</artifactId>
-        <version>5.2.15-SNAPSHOT</version>
+        <version>5.2.16-SNAPSHOT</version>
     </parent>
     <artifactId>PlayerHeads-base-api</artifactId>
     <packaging>jar</packaging>

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/HeadRollEvent.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/HeadRollEvent.java
@@ -5,9 +5,16 @@
  */
 package org.shininet.bukkit.playerheads.events;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.shininet.bukkit.playerheads.events.modifiers.DropRateModifier;
+import org.shininet.bukkit.playerheads.events.modifiers.DropRateModifierType;
 
 /**
  * Event created by PlayerHeads (4.9.2+) to indicate that a head dropchance roll
@@ -16,6 +23,7 @@ import org.bukkit.event.HandlerList;
  * factors considered by PlayerHeads available. If the success of this event is
  * set to false, no head will be dropped. If it is set to true, a head will be
  * dropped.
+ *
  * @since 4.9.2-SNAPSHOT
  * @author crashdemons (crashenator at gmail.com)
  */
@@ -23,25 +31,60 @@ public class HeadRollEvent extends Event {
 
     private static final HandlerList HANDLERS = new HandlerList();
 
+    private final LinkedHashMap<String, DropRateModifier> modifiers = new LinkedHashMap<>();
+
     private final Entity killer;
     private final Entity target;
 
     private final boolean killerAlwaysBeheads;
-    private final double lootingModifier;
-    private final double slimeModifier;
-    private final double chargedCreeperModifier;
 
     private final double originalDropRoll;
-    private final double effectiveDropRoll;
+    private double effectiveDropRoll;
     private final double originalDropRate;
-    private final double effectiveDropRate;
+    private double effectiveDropRate;
+
     private boolean dropSuccess;
-    
+
     /**
-     * Creates the Head dropchance event for PlayerHeads.
-     * 
-     * 5.2+ API
-     * @since 5.2.0-SNAPSHOT
+     * Creates the Head dropchance event for PlayerHeads without precalculation,
+     * allowing for event-based recalculation. Success is disabled by default.
+     *
+     * Note: this method does not add any modifier values by default.
+     *
+     * 5.2.2+ API
+     *
+     * @since 5.3.0-SNAPSHOT
+     *
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1. logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     */
+    public HeadRollEvent(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double originalDropRoll, final double originalDropRate) {
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = originalDropRate;
+        this.dropSuccess = false;
+        this.effectiveDropRoll = originalDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+
+        this.killer = killer;
+        this.target = target;
+    }
+
+    /**
+     * Creates the Head dropchance event for PlayerHeads with values
+     * precalaculated by the plugin.
+     *
+     * Note: this method does not add any modifier values by default.
+     *
+     * 5.2.2+ API
+     *
+     * @since 5.3.0-SNAPSHOT
      *
      * @param killer the Entity beheading another
      * @param target the Entity being beheaded
@@ -49,11 +92,6 @@ public class HeadRollEvent extends Event {
      * permission
      * @param originalDropRoll the randomized PRNG double droproll value
      * inclusively between 0 to 1.
-     * @param slimeModifier the fraction of the slime/magmacube drop rate that is applicable at this size, modifuing the effective droprate (0.5 is 50% of the base rate). This should be 1.0 when there is no effect or the entity is not a slime.
-     * @param lootingModifier the fractional probability modifier (greater than
-     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
-     * droprate.
-     * @param chargedCreeperModifier the multiplier effect that charged creepers have on normal droprates
      * @param effectiveDropRoll the modified droproll value after permission
      * logic was applied (alwaysbehead sets to 0)
      * @param originalDropRate the configured droprate of the target as a
@@ -63,21 +101,66 @@ public class HeadRollEvent extends Event {
      * @param dropSuccess whether the droproll was determined to be initially a
      * successful roll.
      */
-    public HeadRollEvent(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double chargedCreeperModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
-        this.lootingModifier = lootingModifier;
+    public HeadRollEvent(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
         this.originalDropRate = originalDropRate;
         this.effectiveDropRate = effectiveDropRate;
         this.dropSuccess = dropSuccess;
         this.effectiveDropRoll = effectiveDropRoll;
         this.originalDropRoll = originalDropRoll;
         this.killerAlwaysBeheads = killerAlwaysBeheads;
-        this.slimeModifier=slimeModifier;
-        this.chargedCreeperModifier=chargedCreeperModifier;
 
         this.killer = killer;
         this.target = target;
     }
-    
+
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     *
+     * 5.2+ API
+     *
+     * @since 5.2.0-SNAPSHOT
+     *
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param slimeModifier the fraction of the slime/magmacube drop rate that
+     * is applicable at this size, modifuing the effective droprate (0.5 is 50%
+     * of the base rate). This should be 1.0 when there is no effect or the
+     * entity is not a slime.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param chargedCreeperModifier the multiplier effect that charged creepers
+     * have on normal droprates
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    @Deprecated
+    public HeadRollEvent(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double chargedCreeperModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        setModifier("looting", new DropRateModifier(DropRateModifierType.MULTIPLY, lootingModifier));
+        setModifier("slime", new DropRateModifier(DropRateModifierType.MULTIPLY, slimeModifier));
+        setModifier("chargedcreeper", new DropRateModifier(DropRateModifierType.MULTIPLY, chargedCreeperModifier));
+
+        this.killer = killer;
+        this.target = target;
+    }
+
     /**
      * Creates the Head dropchance event for PlayerHeads.
      *
@@ -88,7 +171,10 @@ public class HeadRollEvent extends Event {
      * permission
      * @param originalDropRoll the randomized PRNG double droproll value
      * inclusively between 0 to 1.
-     * @param slimeModifier the fraction of the slime/magmacube drop rate that is applicable at this size, modifuing the effective droprate (0.5 is 50% of the base rate). This should be 1.0 when there is no effect or the entity is not a slime.
+     * @param slimeModifier the fraction of the slime/magmacube drop rate that
+     * is applicable at this size, modifuing the effective droprate (0.5 is 50%
+     * of the base rate). This should be 1.0 when there is no effect or the
+     * entity is not a slime.
      * @param lootingModifier the fractional probability modifier (greater than
      * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
      * droprate.
@@ -103,19 +189,20 @@ public class HeadRollEvent extends Event {
      */
     @Deprecated
     public HeadRollEvent(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
-        this.lootingModifier = lootingModifier;
         this.originalDropRate = originalDropRate;
         this.effectiveDropRate = effectiveDropRate;
         this.dropSuccess = dropSuccess;
         this.effectiveDropRoll = effectiveDropRoll;
         this.originalDropRoll = originalDropRoll;
         this.killerAlwaysBeheads = killerAlwaysBeheads;
-        this.slimeModifier=slimeModifier;
-        this.chargedCreeperModifier=1.0;
+
+        setModifier("looting", new DropRateModifier(DropRateModifierType.MULTIPLY, lootingModifier));
+        setModifier("slime", new DropRateModifier(DropRateModifierType.MULTIPLY, slimeModifier));
 
         this.killer = killer;
         this.target = target;
     }
+
     /**
      * Creates the Head dropchance event for PlayerHeads.
      *
@@ -139,54 +226,238 @@ public class HeadRollEvent extends Event {
      */
     @Deprecated
     public HeadRollEvent(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
-        this.lootingModifier = lootingModifier;
         this.originalDropRate = originalDropRate;
         this.effectiveDropRate = effectiveDropRate;
         this.dropSuccess = dropSuccess;
         this.effectiveDropRoll = effectiveDropRoll;
         this.originalDropRoll = originalDropRoll;
         this.killerAlwaysBeheads = killerAlwaysBeheads;
-        this.slimeModifier=1.0;
-        this.chargedCreeperModifier=1.0;
+        setModifier("looting", new DropRateModifier(DropRateModifierType.MULTIPLY, lootingModifier));
 
         this.killer = killer;
         this.target = target;
     }
 
- 
     /**
-     * Gets the charged creeper modifier (multiplier) that modified the effective
-     * droprate. Generally this is 1 (no effect) when the mob was not detected to be killed by a charged creeper.
-     * 
-     * 5.2+ API
-     * @since 5.2.0-SNAPSHOT
+     * Gets the list of modifiers to the effective droprate. This map will be in
+     * order that the modifiers are applied.
      *
+     * @since 5.3.0-SNAPSHOT
+     * @return map containing the droprate modifiers by name.
+     */
+    @NotNull
+    public Map<String, DropRateModifier> getModifiers() {
+        return modifiers;
+    }
+
+    /**
+     * Re-apply the current effective droproll and effective droprate values to
+     * make a new determination of the head drop's success. Modifiers are not
+     * considered by this method, only the two effective values. Note: if
+     * killerAlwaysBeheads is enabled, the effective droproll will be set to 0.
+     *
+     * @since 5.3.0-SNAPSHOT
+     */
+    public void applyDropRate() {
+        if (killerAlwaysBeheads) {
+            effectiveDropRoll = 0;
+        }
+        this.setDropSuccess(effectiveDropRoll < effectiveDropRate);
+    }
+
+    /**
+     * Re-apply all droprate modifiers to the original droprate and recalculate
+     * the effective droprate. This method will discard the current effective
+     * droprate, if you want to retain the original values, you should copy them
+     * before calling this method. Success is not updated by this method.
+     *
+     * @since 5.3.0-SNAPSHOT
+     */
+    public void applyModifiers() {
+        effectiveDropRate = originalDropRate;
+        for (DropRateModifier modifier : modifiers.values()) {
+            effectiveDropRate = modifier.apply(effectiveDropRate);
+        }
+    }
+
+    /**
+     * Re-apply all factors (droprate modifiers then effective values) to
+     * determine suuccess. This method will discard the current effective
+     * droprate, if you want to retain the original values, you should copy them
+     * before calling this method.
+     *
+     * @since 5.3.0-SNAPSHOT
+     */
+    public void recalculateSuccess() {
+        applyModifiers();
+        applyDropRate();
+    }
+
+    /**
+     * Retrieve the value of a modifier of the effective droprate. Note: this
+     * value does not impact calculations or success and is for you to use as a
+     * courtesy to other plugins at this point. This method can retrieve both
+     * internal and custom plugin modifiers (if the prefix is included).
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param modifierName the name of the modifier
+     * @return the value of the modifier, or null if it is not present.
+     */
+    @Nullable
+    public DropRateModifier getModifier(final String modifierName) {
+        return modifiers.get(modifierName);
+    }
+
+    /**
+     * Sets a note about an internal modifier of the effective droprate. Note:
+     * this value does not impact calculations or success unless applyModifiers
+     * is called Note: new modifies are generally applied AFTER other
+     * modifiers<br>
+     *
+     * @deprecated using this method to modify existing modifiers should be
+     * avoided - use setCustomModifier to note new ones.
+     * @since 5.3.0-SNAPSHOT
+     * @param modifierName the name of the modifier to set.
+     * @param value the value of the modifier to set
+     */
+    public void setModifier(final String modifierName, final DropRateModifier value) {
+        modifiers.put(modifierName, value);
+    }
+
+    /**
+     * Replaces notes about an internal modifiers of the effective droprate.
+     * Note: this value does not impact calculations or success unless
+     * applyModifiers is called Note: new modifies are generally applied AFTER
+     * other modifiers; this method will overwrite existing modifiers.<br>
+     *
+     * @deprecated using this method to modify existing modifiers should be
+     * avoided - use setCustomModifier to note new ones.
+     * @since 5.3.0-SNAPSHOT
+     * @param entries the modifiers to set
+     */
+    public void setModifiers(final Map<String, DropRateModifier> entries) {
+        modifiers.clear();
+        modifiers.putAll(entries);
+    }
+
+    /**
+     * Constructs the internal name of a custom droprate modifier, provided the
+     * name of the plugin and modifier.
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param pluginName The name of the plugin that added the modifier
+     * @param modifierName The name of the modifier
+     * @return the internal name of the modifier;
+     */
+    public static String getCustomModifierName(final String pluginName, final String modifierName) {
+        return pluginName + ":" + modifierName;
+    }
+
+    /**
+     * Add or change a note about your custom modifier to the head-roll event.
+     * Note: this value does not impact calculations or success unless
+     * applyModifiers is called.<br>
+     * Note: the name of the modifier will be prepended with "PluginName:"
+     * depending on your plugin's name.<br>
+     * Note: new modifies are generally applied AFTER other modifiers<br>
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param yourPlugin the plugin adding the modifier
+     * @param modifierName the name of the modifier, excluding any prefix
+     * @param modifierValue the value of the modifier
+     */
+    public void setCustomModifier(final Plugin yourPlugin, final String modifierName, final DropRateModifier modifierValue) {
+        String customModifierName = getCustomModifierName(yourPlugin.getName(), modifierName);
+        modifiers.put(customModifierName, modifierValue);
+    }
+
+    /**
+     * Gets a custom (plugin-added) modifier to the head-roll event. Note: this
+     * value does not impact calculations or success and is for you to use as a
+     * courtesy to other plugins at this point. Note: the name of the modifier
+     * will be prepended with "PluginName:" depending on your plugin's name.
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param yourPlugin the plugin which added the modifier
+     * @param modifierName the name of the modifier, excluding any prefix
+     * @return the value of the modifier, or the null if it is not found.
+     */
+    public DropRateModifier getCustomModifier(final Plugin yourPlugin, final String modifierName) {
+        return getCustomModifier(yourPlugin.getName(), modifierName);
+    }
+
+    /**
+     * Gets a custom (plugin-added) modifier to the head-roll event. Note: this
+     * value does not impact calculations or success and is for you to use as a
+     * courtesy to other plugins at this point. Note: the name of the modifier
+     * will be prepended with "PluginName:" depending on your plugin's name.
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param yourPluginName the plugin name which added the modifier
+     * @param modifierName the name of the modifier, excluding any prefix
+     * @return the value of the modifier, or the null if it is not found.
+     */
+    public DropRateModifier getCustomModifier(final String yourPluginName, final String modifierName) {
+        String customModifierName = getCustomModifierName(yourPluginName, modifierName);
+        return getModifier(customModifierName);
+    }
+
+    /**
+     * Gets the charged creeper modifier (multiplier) that modified the
+     * effective droprate. Generally this is 1 (no effect) when the mob was not
+     * detected to be killed by a charged creeper.
+     *
+     * 5.2+ API
+     *
+     * @since 5.2.0-SNAPSHOT
+     * @deprecated use getModifier("chargedcreeper") instead
+     * @see #getModifier(java.lang.String) 
      * @return the multiplier
      */
+    @NotNull
     public double getChargedCreeperModifier() {
-        return chargedCreeperModifier;
+        DropRateModifier modifier = getModifier("chargedcreeper");
+        if (modifier == null) {
+            return 1;
+        }
+        return modifier.getMultiplierValue();
     }
-    
+
     /**
-     * Gets the slime/magmacube size modifier (multiplier) that modified the effective
-     * droprate. Generally this is 1 (no effect) when not a slime.
+     * Gets the slime/magmacube size modifier (multiplier) that modified the
+     * effective droprate. Generally this is 1 (no effect) when not a slime.
+     *
      * @since 5.1.0-SNAPSHOT
+     * @deprecated use getModifier("slime") instead
+     * @see #getModifier(java.lang.String)
      * @return the looting modifier
      */
+    @NotNull
     public double getSlimeModifier() {
-        return slimeModifier;
+        DropRateModifier modifier = getModifier("slime");
+        if (modifier == null) {
+            return 1;
+        }
+        return modifier.getMultiplierValue();
     }
-    
+
     /**
-     * Gets the looting modifier (multiplier) that modified the effective
-     * droprate. Generally this is 1 (no effect) or greater.
-     * 
-     * Note: lootingmodifier = (1 + Config_lootingrate * Entity_Looting_Enchantment_Level)
+     * Gets the effective looting modifier (multiplier) that modified the
+     * effective droprate. Generally this is 1 (no effect) or greater.
      *
+     * Note: lootingmodifier = (1 + Config_lootingrate *
+     * Entity_Looting_Enchantment_Level)
+     *
+     * @deprecated use getModifier("looting") instead
+     * @see #getModifier(java.lang.String)
      * @return the looting modifier
      */
     public double getLootingModifier() {
-        return lootingModifier;
+        DropRateModifier modifier = getModifier("looting");
+        if (modifier == null) {
+            return 1;
+        }
+        return modifier.getMultiplierValue();
     }
 
     /**
@@ -231,6 +502,31 @@ public class HeadRollEvent extends Event {
     }
 
     /**
+     * Sets the effective droproll value for the event. Note: this value will
+     * not impact the success value or calculations unless applyDropRate() or
+     * recalculateSuccess() is called.
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param effectiveRoll the value between 0.0 and 1.0 to use as the drop
+     * roll.
+     */
+    public void setEffectiveDropRoll(final double effectiveRoll) {
+        this.effectiveDropRoll = effectiveRoll;
+    }
+
+    /**
+     * Sets the effective droprate value for the event. Note: this value is only
+     * for indication purposes to other plugins, and will be overwritten by
+     * apply and recalculate methods.
+     *
+     * @since 5.3.0-SNAPSHOT
+     * @param effectiveRate the effective droprate/fractional-chance value to set (0.0-1.0 inclusive)
+     */
+    public void setEffectiveDropRate(final double effectiveRate) {
+        this.effectiveDropRate = effectiveRate;
+    }
+
+    /**
      * Gets the effective drop roll value after modification by PlayerHeads. The
      * droproll will normally be reflected by the original random droproll,
      * except if the killer always beheads, then this may be 0. If this is below
@@ -256,8 +552,9 @@ public class HeadRollEvent extends Event {
     /**
      * Gets the configured droprate for the target as a fractional probability,
      * after modification by looting and slime size modifier.
-     * 
-     * Note: effectiveDroprate = originalDropRate * lootingModifier * slimeModifier.
+     *
+     * Note: effectiveDroprate = originalDropRate * lootingModifier *
+     * slimeModifier.
      *
      * @return the droprate
      */

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/HeadRollEvent.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/HeadRollEvent.java
@@ -53,7 +53,7 @@ public class HeadRollEvent extends Event {
      *
      * 5.2.2+ API
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      *
      * @param killer the Entity beheading another
      * @param target the Entity being beheaded
@@ -84,7 +84,7 @@ public class HeadRollEvent extends Event {
      *
      * 5.2.2+ API
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      *
      * @param killer the Entity beheading another
      * @param target the Entity being beheaded
@@ -242,7 +242,7 @@ public class HeadRollEvent extends Event {
      * Gets the list of modifiers to the effective droprate. This map will be in
      * order that the modifiers are applied.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @return map containing the droprate modifiers by name.
      */
     @NotNull
@@ -256,7 +256,7 @@ public class HeadRollEvent extends Event {
      * considered by this method, only the two effective values. Note: if
      * killerAlwaysBeheads is enabled, the effective droproll will be set to 0.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      */
     public void applyDropRate() {
         if (killerAlwaysBeheads) {
@@ -271,7 +271,7 @@ public class HeadRollEvent extends Event {
      * droprate, if you want to retain the original values, you should copy them
      * before calling this method. Success is not updated by this method.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      */
     public void applyModifiers() {
         effectiveDropRate = originalDropRate;
@@ -286,7 +286,7 @@ public class HeadRollEvent extends Event {
      * droprate, if you want to retain the original values, you should copy them
      * before calling this method.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      */
     public void recalculateSuccess() {
         applyModifiers();
@@ -299,7 +299,7 @@ public class HeadRollEvent extends Event {
      * courtesy to other plugins at this point. This method can retrieve both
      * internal and custom plugin modifiers (if the prefix is included).
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param modifierName the name of the modifier
      * @return the value of the modifier, or null if it is not present.
      */
@@ -316,7 +316,7 @@ public class HeadRollEvent extends Event {
      *
      * @deprecated using this method to modify existing modifiers should be
      * avoided - use setCustomModifier to note new ones.
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param modifierName the name of the modifier to set.
      * @param value the value of the modifier to set
      */
@@ -332,7 +332,7 @@ public class HeadRollEvent extends Event {
      *
      * @deprecated using this method to modify existing modifiers should be
      * avoided - use setCustomModifier to note new ones.
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param entries the modifiers to set
      */
     public void setModifiers(final Map<String, DropRateModifier> entries) {
@@ -344,7 +344,7 @@ public class HeadRollEvent extends Event {
      * Constructs the internal name of a custom droprate modifier, provided the
      * name of the plugin and modifier.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param pluginName The name of the plugin that added the modifier
      * @param modifierName The name of the modifier
      * @return the internal name of the modifier;
@@ -361,7 +361,7 @@ public class HeadRollEvent extends Event {
      * depending on your plugin's name.<br>
      * Note: new modifies are generally applied AFTER other modifiers<br>
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param yourPlugin the plugin adding the modifier
      * @param modifierName the name of the modifier, excluding any prefix
      * @param modifierValue the value of the modifier
@@ -377,7 +377,7 @@ public class HeadRollEvent extends Event {
      * courtesy to other plugins at this point. Note: the name of the modifier
      * will be prepended with "PluginName:" depending on your plugin's name.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param yourPlugin the plugin which added the modifier
      * @param modifierName the name of the modifier, excluding any prefix
      * @return the value of the modifier, or the null if it is not found.
@@ -392,7 +392,7 @@ public class HeadRollEvent extends Event {
      * courtesy to other plugins at this point. Note: the name of the modifier
      * will be prepended with "PluginName:" depending on your plugin's name.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param yourPluginName the plugin name which added the modifier
      * @param modifierName the name of the modifier, excluding any prefix
      * @return the value of the modifier, or the null if it is not found.
@@ -506,7 +506,7 @@ public class HeadRollEvent extends Event {
      * not impact the success value or calculations unless applyDropRate() or
      * recalculateSuccess() is called.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param effectiveRoll the value between 0.0 and 1.0 to use as the drop
      * roll.
      */
@@ -519,7 +519,7 @@ public class HeadRollEvent extends Event {
      * for indication purposes to other plugins, and will be overwritten by
      * apply and recalculate methods.
      *
-     * @since 5.3.0-SNAPSHOT
+     * @since 5.2.16-SNAPSHOT
      * @param effectiveRate the effective droprate/fractional-chance value to set (0.0-1.0 inclusive)
      */
     public void setEffectiveDropRate(final double effectiveRate) {

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/HeadRollEvent_old.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/HeadRollEvent_old.java
@@ -1,0 +1,317 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+ */
+package org.shininet.bukkit.playerheads.events;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event created by PlayerHeads (4.9.2+) to indicate that a head dropchance roll
+ * has occurred and the success/failure has been determined. This event allows
+ * third-party plugin authors to analyze and modify drop chance success with all
+ * factors considered by PlayerHeads available. If the success of this event is
+ * set to false, no head will be dropped. If it is set to true, a head will be
+ * dropped.
+ * @since 4.9.2-SNAPSHOT
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class HeadRollEvent_old extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Entity killer;
+    private final Entity target;
+
+    private final boolean killerAlwaysBeheads;
+    private final double lootingModifier;
+    private final double slimeModifier;
+    private final double chargedCreeperModifier;
+
+    private final double originalDropRoll;
+    private final double effectiveDropRoll;
+    private final double originalDropRate;
+    private final double effectiveDropRate;
+    private boolean dropSuccess;
+    
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     * 
+     * 5.2+ API
+     * @since 5.2.0-SNAPSHOT
+     *
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param slimeModifier the fraction of the slime/magmacube drop rate that is applicable at this size, modifuing the effective droprate (0.5 is 50% of the base rate). This should be 1.0 when there is no effect or the entity is not a slime.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param chargedCreeperModifier the multiplier effect that charged creepers have on normal droprates
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    public HeadRollEvent_old(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double chargedCreeperModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+        this.lootingModifier = lootingModifier;
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        this.slimeModifier=slimeModifier;
+        this.chargedCreeperModifier=chargedCreeperModifier;
+
+        this.killer = killer;
+        this.target = target;
+    }
+    
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     *
+     * @since 5.1.0-SNAPSHOT
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param slimeModifier the fraction of the slime/magmacube drop rate that is applicable at this size, modifuing the effective droprate (0.5 is 50% of the base rate). This should be 1.0 when there is no effect or the entity is not a slime.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    @Deprecated
+    public HeadRollEvent_old(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+        this.lootingModifier = lootingModifier;
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        this.slimeModifier=slimeModifier;
+        this.chargedCreeperModifier=1.0;
+
+        this.killer = killer;
+        this.target = target;
+    }
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     *
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    @Deprecated
+    public HeadRollEvent_old(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+        this.lootingModifier = lootingModifier;
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        this.slimeModifier=1.0;
+        this.chargedCreeperModifier=1.0;
+
+        this.killer = killer;
+        this.target = target;
+    }
+
+ 
+    /**
+     * Gets the charged creeper modifier (multiplier) that modified the effective
+     * droprate. Generally this is 1 (no effect) when the mob was not detected to be killed by a charged creeper.
+     * 
+     * 5.2+ API
+     * @since 5.2.0-SNAPSHOT
+     *
+     * @return the multiplier
+     */
+    public double getChargedCreeperModifier() {
+        return chargedCreeperModifier;
+    }
+    
+    /**
+     * Gets the slime/magmacube size modifier (multiplier) that modified the effective
+     * droprate. Generally this is 1 (no effect) when not a slime.
+     * @since 5.1.0-SNAPSHOT
+     * @return the looting modifier
+     */
+    public double getSlimeModifier() {
+        return slimeModifier;
+    }
+    
+    /**
+     * Gets the looting modifier (multiplier) that modified the effective
+     * droprate. Generally this is 1 (no effect) or greater.
+     * 
+     * Note: lootingmodifier = (1 + Config_lootingrate * Entity_Looting_Enchantment_Level)
+     *
+     * @return the looting modifier
+     */
+    public double getLootingModifier() {
+        return lootingModifier;
+    }
+
+    /**
+     * Get the Killer's entity that may have done the beheading.
+     *
+     * @return the entity of the killer, or null if the killer was a mob.
+     */
+    public Entity getKiller() {
+        return killer;
+    }
+
+    /**
+     * Get the Target's entity that may have been beheaded
+     *
+     * @return the entity of the target
+     */
+    public Entity getTarget() {
+        return target;
+    }
+
+    /**
+     * Gets whether the killer was configured to always behead this type of
+     * target. Note: this may differ on whether the target was a player or mob.
+     * If this is true, the effective droproll may have been set to 0 to force
+     * success.
+     *
+     * @return Whether the killer was configured to always behead
+     */
+    public boolean getKillerAlwaysBeheads() {
+        return killerAlwaysBeheads;
+    }
+
+    /**
+     * Gets the original PRNG-generated random value of the drop roll, uniform
+     * between 0 and 1 inclusively. When this value is lower than the droprate
+     * value by chance, the roll is considered successful.
+     *
+     * @return the drop roll value in the range [0,1]
+     */
+    public double getOriginalDropRoll() {
+        return originalDropRoll;
+    }
+
+    /**
+     * Gets the effective drop roll value after modification by PlayerHeads. The
+     * droproll will normally be reflected by the original random droproll,
+     * except if the killer always beheads, then this may be 0. If this is below
+     * the droprate, the roll would have been determined to be a success.
+     *
+     * @return the effective drop roll.
+     * @see #getOriginalDropRoll
+     */
+    public double getEffectiveDropRoll() {
+        return effectiveDropRoll;
+    }
+
+    /**
+     * Gets the configured droprate for the target as a fractional probability,
+     * unmodified.
+     *
+     * @return the droprate
+     */
+    public double getOriginalDropRate() {
+        return originalDropRate;
+    }
+
+    /**
+     * Gets the configured droprate for the target as a fractional probability,
+     * after modification by looting and slime size modifier.
+     * 
+     * Note: effectiveDroprate = originalDropRate * lootingModifier * slimeModifier.
+     *
+     * @return the droprate
+     */
+    public double getEffectiveDropRate() {
+        return effectiveDropRate;
+    }
+
+    /**
+     * Whether the effective drop roll was determined to be a success.
+     *
+     * @return the success of the drop roll
+     */
+    public boolean getDropSuccess() {
+        return dropSuccess;
+    }
+
+    /**
+     * Sets whether the drop roll should be considered a success.
+     *
+     * @param value whether the head drop should succeed or fail.
+     */
+    public void setDropSuccess(final boolean value) {
+        dropSuccess = value;
+    }
+
+    /**
+     * Whether the effective drop roll was determined to be a success. Alias of
+     * getDropSuccess
+     *
+     * @see #getDropSuccess()
+     * @return the success of the drop roll
+     */
+    public boolean succeeded() {
+        return getDropSuccess();
+    }
+
+    /**
+     * Get a list of handlers for the event.
+     *
+     * @return a list of handlers for the event
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Get a list of handlers for the event.
+     *
+     * @return a list of handlers for the event
+     */
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+}

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifier.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifier.java
@@ -8,6 +8,7 @@ package org.shininet.bukkit.playerheads.events.modifiers;
 /**
  * A modifier for the droprate including type and value information
  *
+ * @since 5.2.16-SNAPSHOT
  * @author crashdemons (crashenator at gmail.com)
  */
 public class DropRateModifier {

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifier.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifier.java
@@ -1,0 +1,130 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+ */
+package org.shininet.bukkit.playerheads.events.modifiers;
+
+/**
+ * A modifier for the droprate including type and value information
+ *
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class DropRateModifier {
+
+    private final DropRateModifierType type;
+    private final double value;
+    private final int level;
+
+    /**
+     * Constructs a modifier with a value that is multiplied by a level of
+     * effectiveness
+     *
+     * @param type the type of modifier
+     * @param value the base value of the modifier
+     * @param level the level to be multiplied against the modifier
+     */
+    public DropRateModifier(final DropRateModifierType type, final double value, final int level) {
+        this.type = type;
+        this.value = value;
+        this.level = level;
+    }
+    
+    /**
+     * Constructs a modifier of a given type and value
+     *
+     * @param type the type of modifier
+     * @param value the value of the modifier
+     */
+    public DropRateModifier(final DropRateModifierType type, final double value) {
+        this(type, value, 1);
+    }
+    
+    /**
+     * Gets the effectiveness level of the modifier. Note: this only provides a
+     * useful result with modifiers of type ADD_MULTIPLE_PER_LEVEL, otherwise it
+     * will return 1.
+     *
+     * @return the effectiveness level of the modifier, or 1.
+     */
+    public int getLevel() {
+        return level;
+    }
+
+    /**
+     * Gets the type of modifier
+     * @return the type of modifier
+     */
+    public DropRateModifierType getType() {
+        return type;
+    }
+
+    /**
+     * Returns the value or rate applied by the modifier
+     * @return the value or rate applied by the modifier
+     */
+    public double getValue() {
+        return value;
+    }
+
+    /**
+     * Converts the modifier into an equivalent add-multiple value where
+     * droprate*(1+newvalue) is equivalent to the current modifier effect. Note:
+     * only other multipliers can be converted.
+     *
+     * @return the equivalent additive multiplier value, or null.
+     */
+    public Double getAdditiveMultiplierValue() {
+        if (type == DropRateModifierType.MULTIPLY) {
+            return value - 1.0;
+        }
+        if (type == DropRateModifierType.ADD_MULTIPLE) {
+            return value;
+        }
+        if (type == DropRateModifierType.ADD_MULTIPLE_PER_LEVEL) {
+            return value * level;
+        }
+        return null;
+    }
+
+    /**
+     * Converts the modifier value to a multiplier (1.0=no effect) if possible.
+     * Note: only additive multipliers can be converted to multipliers.
+     *
+     * @return the equivalent multiplier value, or null.
+     */
+    public Double getMultiplierValue() {
+        if (type == DropRateModifierType.MULTIPLY) {
+            return value;
+        }
+        if (type == DropRateModifierType.ADD_MULTIPLE) {
+            return 1.0 + value;
+        }
+        if (type == DropRateModifierType.ADD_MULTIPLE_PER_LEVEL) {
+            return 1.0 + value * level;
+        }
+        return null;
+    }
+
+    /**
+     * Apply the droprate modifier to the droprate value
+     *
+     * @param droprate a droprate between 0 (0% chance) and 1.0 (100% chance).
+     * Higher values also indicate 100% chance.
+     * @return the effective droprate after modification
+     */
+    public double apply(final double droprate) {
+        switch (type) {
+            case MULTIPLY:
+                return droprate * value;
+            case ADD_MULTIPLE:
+                return droprate * (1.0 + value);
+            case ADD_MULTIPLE_PER_LEVEL:
+                return droprate * (1.0 + value * level);
+            case ADD_CONSTANT:
+                return droprate + value;
+            default:
+                throw new IllegalArgumentException("An unsupported droprate modifier type was detected.");
+        }
+    }
+}

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifierType.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifierType.java
@@ -1,0 +1,34 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+ */
+package org.shininet.bukkit.playerheads.events.modifiers;
+
+/**
+ * Indicates the type of modifier to the effective droprate
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public enum DropRateModifierType {
+    /**
+     * adds a constant value to the droprate
+     */
+    ADD_CONSTANT,
+    
+    /**
+     * adds a VALUE*droprate to the droprate. This is equivalent to a multiplier of 1+VALUE. Positive values increase droprate by a fraction, negative values will reduuce the droprate by a fraction.
+     * In this way, additive multipliers can be thought of as a delta value.
+     */
+    ADD_MULTIPLE,
+    
+    /**
+     * adds a value to the droprate where the value is a multiple of a provided effectiveness level. this is equivalent to a multiplier of (1+VALUE*LEVEL)
+     */
+    ADD_MULTIPLE_PER_LEVEL,
+    
+    /**
+     * Multiplies the droprate against a value. Values under 1 reduce the droprate, values above 1 are equivalent to additive multipliers 
+     */
+    MULTIPLY,
+    
+}

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifierType.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifierType.java
@@ -6,7 +6,9 @@
 package org.shininet.bukkit.playerheads.events.modifiers;
 
 /**
- * Indicates the type of modifier to the effective droprate
+ * Indicates the type of modifier to the effective droprate.
+ * 
+ * @since 5.2.16-SNAPSHOT
  * @author crashdemons (crashenator at gmail.com)
  */
 public enum DropRateModifierType {

--- a/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/package-info.java
+++ b/PlayerHeads-base-api/src/main/java/org/shininet/bukkit/playerheads/events/modifiers/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Defines droprate modifier values for HeadRollEvent
+ * @since 5.3.0-SNAPSHOT
+ * @author crashdemons (crashenator at gmail dot com)
+ */
+package org.shininet.bukkit.playerheads.events.modifiers;

--- a/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEventTest.java
+++ b/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEventTest.java
@@ -6,6 +6,7 @@
 package org.shininet.bukkit.playerheads.events;
 
 import java.util.Map;
+import java.util.Random;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
@@ -20,9 +21,57 @@ import org.shininet.bukkit.playerheads.events.modifiers.DropRateModifierType;
  */
 public class HeadRollEventTest {
     
+    PHListenerDummy listener = new PHListenerDummy();
+    private final Random rand = new Random();
+    private final double epsilon = Math.ulp(1.0);
+    
     public HeadRollEventTest() {
     }
 
+    
+    public double getTestValue(){//randomish value between -2.0 and +2.0
+        double value = rand.nextDouble() + rand.nextDouble();//choose a value between 0.0 and 2.0 (not necessarily uniform but that's fine)
+        return rand.nextBoolean() ? +value : -value; //choose randomly whether it will be negative
+    }
+    
+    public void testNewOldRandParams(){
+        Double droprateOriginal = getTestValue();
+        Double lootingModifier = getTestValue();
+        Double slimeModifier = getTestValue();
+        Double chargedcreeperModifier = getTestValue();
+        //System.out.println(droprateOriginal);
+        Object[] arr = listener.MobDeathHelper(null, null, null,  droprateOriginal,  lootingModifier,  slimeModifier,  chargedcreeperModifier);
+        if(arr!=null){
+            HeadRollEvent_old a = (HeadRollEvent_old) arr[0];
+            HeadRollEvent b = (HeadRollEvent) arr[1];
+            
+            assertEquals(a.getChargedCreeperModifier(),b.getChargedCreeperModifier(),epsilon);
+            assertEquals(a.getSlimeModifier(),b.getSlimeModifier(),epsilon);
+            assertEquals(a.getLootingModifier(),b.getLootingModifier(),epsilon);
+            assertEquals(a.getOriginalDropRate(),b.getOriginalDropRate(),epsilon);
+            assertEquals(a.getOriginalDropRoll(),b.getOriginalDropRoll(),epsilon);
+            assertEquals(a.getEffectiveDropRate(),b.getEffectiveDropRate(),epsilon);
+            assertEquals(a.getEffectiveDropRoll(),b.getEffectiveDropRoll(),epsilon);
+            
+            b.recalculateSuccess();//applyModifiers and applyDroprate
+            
+            assertEquals(a.getChargedCreeperModifier(),b.getChargedCreeperModifier(),epsilon);
+            assertEquals(a.getSlimeModifier(),b.getSlimeModifier(),epsilon);
+            assertEquals(a.getLootingModifier(),b.getLootingModifier(),epsilon);
+            assertEquals(a.getOriginalDropRate(),b.getOriginalDropRate(),epsilon);
+            assertEquals(a.getOriginalDropRoll(),b.getOriginalDropRoll(),epsilon);
+            assertEquals(a.getEffectiveDropRate(),b.getEffectiveDropRate(),epsilon);
+        }
+    }
+    
+    @Test
+    public void testNewOldN(){ //test 5.3 (now 5.2.16) headrollevent against 5.2.15 calculation
+        System.out.println("epsilon = "+epsilon);
+        for(int i=0;i<100000;i++){
+            testNewOldRandParams();
+        }
+    }
+    
     @Test
     public void testGetModifiers() {
         System.out.println("getModifiers");

--- a/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEventTest.java
+++ b/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEventTest.java
@@ -1,0 +1,119 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+ */
+package org.shininet.bukkit.playerheads.events;
+
+import java.util.Map;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.shininet.bukkit.playerheads.events.modifiers.DropRateModifier;
+import org.shininet.bukkit.playerheads.events.modifiers.DropRateModifierType;
+
+/**
+ *
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class HeadRollEventTest {
+    
+    public HeadRollEventTest() {
+    }
+
+    @Test
+    public void testGetModifiers() {
+        System.out.println("getModifiers");
+        HeadRollEvent instance = new HeadRollEvent(null, null, false, 0.2, 0.75);
+        Map<String, DropRateModifier> result = instance.getModifiers();
+        assertEquals(0,result.size());
+        
+        instance = new HeadRollEvent(null, null, false, 0.2, 0.75);
+        instance.setModifier("testModifier", new DropRateModifier(DropRateModifierType.MULTIPLY,0.035));
+        result = instance.getModifiers();
+        assertEquals(1,result.size());
+        assertEquals((Double) 0.035, (Double) result.get("testModifier").getValue());
+        
+    }
+    @Test
+    public void testApplyDropRate() {
+        System.out.println("applyDropRate");
+        HeadRollEvent instance;
+        instance = new HeadRollEvent(null, null, false, 0.2, 0);
+        instance.applyDropRate();
+        assertFalse(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, false, 0, 0);
+        instance.applyDropRate();
+        assertFalse(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, false, 0.20001, 0.2);
+        instance.applyDropRate();
+        assertFalse(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, false, 0.2, 0.2);
+        instance.applyDropRate();
+        assertFalse(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, false, 0.1999, 0.2);
+        instance.applyDropRate();
+        assertTrue(instance.getDropSuccess());
+    }
+    @Test
+    public void testApplyDropRateABH() {
+        System.out.println("applyDropRateABH");
+        HeadRollEvent instance;
+        instance = new HeadRollEvent(null, null, true, 0.2, 0);
+        instance.applyDropRate();
+        assertFalse(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, true, 0, 0);
+        instance.applyDropRate();
+        assertFalse(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, true, 0.20001, 0.2);
+        instance.applyDropRate();
+        assertTrue(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, true, 0.2, 0.2);
+        instance.applyDropRate();
+        assertTrue(instance.getDropSuccess());
+        instance = new HeadRollEvent(null, null, true, 0.1999, 0.2);
+        instance.applyDropRate();
+        assertTrue(instance.getDropSuccess());
+    }
+    @Test
+    public void testApplyModifiers() {
+        System.out.println("applyModifiers");
+        HeadRollEvent instance;
+        instance = new HeadRollEvent(null, null, true, 0.2, 0.035);
+        instance.applyModifiers();
+        assertEquals(0.035, instance.getEffectiveDropRate(), 0.00000000001);
+        instance = new HeadRollEvent(null, null, true, 0.2, 0.0);
+        instance.applyModifiers();
+        assertEquals(0, instance.getEffectiveDropRate(), 0.00000000001);
+        
+        System.out.println("---");
+        instance = new HeadRollEvent(null, null, true, 0.2, 0.01);
+        instance.setModifier("mod1", new DropRateModifier(DropRateModifierType.ADD_CONSTANT,0.07));
+        instance.applyModifiers();
+        assertEquals( (0.01+0.07), instance.getEffectiveDropRate(), 0.00000000001);
+        System.out.println("");
+        instance.setModifier("mod2", new DropRateModifier(DropRateModifierType.ADD_MULTIPLE,0.02));
+        instance.applyModifiers();
+        assertEquals( (0.01+0.07)*1.02, instance.getEffectiveDropRate(), 0.00000000001);
+        System.out.println("");
+        instance.setModifier("mod3", new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.03,2));
+        instance.applyModifiers();
+        assertEquals( (0.01+0.07)*1.02*(1+0.03*2), instance.getEffectiveDropRate(), 0.00000000001);
+        System.out.println("   expected: "+ ((0.01+0.07)*1.02*(1+0.03*2))+"   was: "+instance.getEffectiveDropRate());
+        System.out.println("");
+        instance.setModifier("mod4", new DropRateModifier(DropRateModifierType.MULTIPLY,1.5));
+        instance.applyModifiers();
+        assertEquals( (0.01+0.07)*1.02*(1+0.03*2)*1.5, instance.getEffectiveDropRate(), 0.00000000001);
+        System.out.println("---");
+        instance.setModifier("mod4", new DropRateModifier(DropRateModifierType.MULTIPLY,1.6));
+        instance.applyModifiers();
+        assertEquals( (0.01+0.07)*1.02*(1+0.03*2)*1.6, instance.getEffectiveDropRate(), 0.00000000001);
+        System.out.println("---");
+        instance.setModifier("mod2", new DropRateModifier(DropRateModifierType.ADD_MULTIPLE,0.06));
+        instance.applyModifiers();
+        assertEquals( (0.01+0.07)*1.06*(1+0.03*2)*1.6, instance.getEffectiveDropRate(), 0.00000000001);
+        System.out.println("---");
+    }
+}

--- a/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEventTest.java
+++ b/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEventTest.java
@@ -52,6 +52,7 @@ public class HeadRollEventTest {
             assertEquals(a.getOriginalDropRoll(),b.getOriginalDropRoll(),epsilon);
             assertEquals(a.getEffectiveDropRate(),b.getEffectiveDropRate(),epsilon);
             assertEquals(a.getEffectiveDropRoll(),b.getEffectiveDropRoll(),epsilon);
+            assertEquals(a.getDropSuccess(),b.getDropSuccess());
             
             b.recalculateSuccess();//applyModifiers and applyDroprate
             
@@ -61,6 +62,7 @@ public class HeadRollEventTest {
             assertEquals(a.getOriginalDropRate(),b.getOriginalDropRate(),epsilon);
             assertEquals(a.getOriginalDropRoll(),b.getOriginalDropRoll(),epsilon);
             assertEquals(a.getEffectiveDropRate(),b.getEffectiveDropRate(),epsilon);
+            assertEquals(a.getDropSuccess(),b.getDropSuccess());
         }
     }
     

--- a/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEvent_old.java
+++ b/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/HeadRollEvent_old.java
@@ -1,0 +1,317 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+ */
+package org.shininet.bukkit.playerheads.events;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event created by PlayerHeads (4.9.2+) to indicate that a head dropchance roll
+ * has occurred and the success/failure has been determined. This event allows
+ * third-party plugin authors to analyze and modify drop chance success with all
+ * factors considered by PlayerHeads available. If the success of this event is
+ * set to false, no head will be dropped. If it is set to true, a head will be
+ * dropped.
+ * @since 4.9.2-SNAPSHOT
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class HeadRollEvent_old extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Entity killer;
+    private final Entity target;
+
+    private final boolean killerAlwaysBeheads;
+    private final double lootingModifier;
+    private final double slimeModifier;
+    private final double chargedCreeperModifier;
+
+    private final double originalDropRoll;
+    private final double effectiveDropRoll;
+    private final double originalDropRate;
+    private final double effectiveDropRate;
+    private boolean dropSuccess;
+    
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     * 
+     * 5.2+ API
+     * @since 5.2.0-SNAPSHOT
+     *
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param slimeModifier the fraction of the slime/magmacube drop rate that is applicable at this size, modifuing the effective droprate (0.5 is 50% of the base rate). This should be 1.0 when there is no effect or the entity is not a slime.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param chargedCreeperModifier the multiplier effect that charged creepers have on normal droprates
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    public HeadRollEvent_old(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double chargedCreeperModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+        this.lootingModifier = lootingModifier;
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        this.slimeModifier=slimeModifier;
+        this.chargedCreeperModifier=chargedCreeperModifier;
+
+        this.killer = killer;
+        this.target = target;
+    }
+    
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     *
+     * @since 5.1.0-SNAPSHOT
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param slimeModifier the fraction of the slime/magmacube drop rate that is applicable at this size, modifuing the effective droprate (0.5 is 50% of the base rate). This should be 1.0 when there is no effect or the entity is not a slime.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    @Deprecated
+    public HeadRollEvent_old(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double slimeModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+        this.lootingModifier = lootingModifier;
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        this.slimeModifier=slimeModifier;
+        this.chargedCreeperModifier=1.0;
+
+        this.killer = killer;
+        this.target = target;
+    }
+    /**
+     * Creates the Head dropchance event for PlayerHeads.
+     *
+     * @param killer the Entity beheading another
+     * @param target the Entity being beheaded
+     * @param killerAlwaysBeheads whether the killer has the always-behead
+     * permission
+     * @param originalDropRoll the randomized PRNG double droproll value
+     * inclusively between 0 to 1.
+     * @param lootingModifier the fractional probability modifier (greater than
+     * or equal to 1.0) of looting, as applied by PlayerHeads to the effective
+     * droprate.
+     * @param effectiveDropRoll the modified droproll value after permission
+     * logic was applied (alwaysbehead sets to 0)
+     * @param originalDropRate the configured droprate of the target as a
+     * fraction (0.01 = 1%)
+     * @param effectiveDropRate the effective droprate of the target as a
+     * fraction (0.01 = 1%), as modified by looting.
+     * @param dropSuccess whether the droproll was determined to be initially a
+     * successful roll.
+     */
+    @Deprecated
+    public HeadRollEvent_old(final Entity killer, final Entity target, final boolean killerAlwaysBeheads, final double lootingModifier, final double originalDropRoll, final double effectiveDropRoll, final double originalDropRate, final double effectiveDropRate, final boolean dropSuccess) {
+        this.lootingModifier = lootingModifier;
+        this.originalDropRate = originalDropRate;
+        this.effectiveDropRate = effectiveDropRate;
+        this.dropSuccess = dropSuccess;
+        this.effectiveDropRoll = effectiveDropRoll;
+        this.originalDropRoll = originalDropRoll;
+        this.killerAlwaysBeheads = killerAlwaysBeheads;
+        this.slimeModifier=1.0;
+        this.chargedCreeperModifier=1.0;
+
+        this.killer = killer;
+        this.target = target;
+    }
+
+ 
+    /**
+     * Gets the charged creeper modifier (multiplier) that modified the effective
+     * droprate. Generally this is 1 (no effect) when the mob was not detected to be killed by a charged creeper.
+     * 
+     * 5.2+ API
+     * @since 5.2.0-SNAPSHOT
+     *
+     * @return the multiplier
+     */
+    public double getChargedCreeperModifier() {
+        return chargedCreeperModifier;
+    }
+    
+    /**
+     * Gets the slime/magmacube size modifier (multiplier) that modified the effective
+     * droprate. Generally this is 1 (no effect) when not a slime.
+     * @since 5.1.0-SNAPSHOT
+     * @return the looting modifier
+     */
+    public double getSlimeModifier() {
+        return slimeModifier;
+    }
+    
+    /**
+     * Gets the looting modifier (multiplier) that modified the effective
+     * droprate. Generally this is 1 (no effect) or greater.
+     * 
+     * Note: lootingmodifier = (1 + Config_lootingrate * Entity_Looting_Enchantment_Level)
+     *
+     * @return the looting modifier
+     */
+    public double getLootingModifier() {
+        return lootingModifier;
+    }
+
+    /**
+     * Get the Killer's entity that may have done the beheading.
+     *
+     * @return the entity of the killer, or null if the killer was a mob.
+     */
+    public Entity getKiller() {
+        return killer;
+    }
+
+    /**
+     * Get the Target's entity that may have been beheaded
+     *
+     * @return the entity of the target
+     */
+    public Entity getTarget() {
+        return target;
+    }
+
+    /**
+     * Gets whether the killer was configured to always behead this type of
+     * target. Note: this may differ on whether the target was a player or mob.
+     * If this is true, the effective droproll may have been set to 0 to force
+     * success.
+     *
+     * @return Whether the killer was configured to always behead
+     */
+    public boolean getKillerAlwaysBeheads() {
+        return killerAlwaysBeheads;
+    }
+
+    /**
+     * Gets the original PRNG-generated random value of the drop roll, uniform
+     * between 0 and 1 inclusively. When this value is lower than the droprate
+     * value by chance, the roll is considered successful.
+     *
+     * @return the drop roll value in the range [0,1]
+     */
+    public double getOriginalDropRoll() {
+        return originalDropRoll;
+    }
+
+    /**
+     * Gets the effective drop roll value after modification by PlayerHeads. The
+     * droproll will normally be reflected by the original random droproll,
+     * except if the killer always beheads, then this may be 0. If this is below
+     * the droprate, the roll would have been determined to be a success.
+     *
+     * @return the effective drop roll.
+     * @see #getOriginalDropRoll
+     */
+    public double getEffectiveDropRoll() {
+        return effectiveDropRoll;
+    }
+
+    /**
+     * Gets the configured droprate for the target as a fractional probability,
+     * unmodified.
+     *
+     * @return the droprate
+     */
+    public double getOriginalDropRate() {
+        return originalDropRate;
+    }
+
+    /**
+     * Gets the configured droprate for the target as a fractional probability,
+     * after modification by looting and slime size modifier.
+     * 
+     * Note: effectiveDroprate = originalDropRate * lootingModifier * slimeModifier.
+     *
+     * @return the droprate
+     */
+    public double getEffectiveDropRate() {
+        return effectiveDropRate;
+    }
+
+    /**
+     * Whether the effective drop roll was determined to be a success.
+     *
+     * @return the success of the drop roll
+     */
+    public boolean getDropSuccess() {
+        return dropSuccess;
+    }
+
+    /**
+     * Sets whether the drop roll should be considered a success.
+     *
+     * @param value whether the head drop should succeed or fail.
+     */
+    public void setDropSuccess(final boolean value) {
+        dropSuccess = value;
+    }
+
+    /**
+     * Whether the effective drop roll was determined to be a success. Alias of
+     * getDropSuccess
+     *
+     * @see #getDropSuccess()
+     * @return the success of the drop roll
+     */
+    public boolean succeeded() {
+        return getDropSuccess();
+    }
+
+    /**
+     * Get a list of handlers for the event.
+     *
+     * @return a list of handlers for the event
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Get a list of handlers for the event.
+     *
+     * @return a list of handlers for the event
+     */
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+}

--- a/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/PHListenerDummy.java
+++ b/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/PHListenerDummy.java
@@ -1,0 +1,68 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.shininet.bukkit.playerheads.events;
+
+import java.util.Random;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+/**
+ *
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class PHListenerDummy {
+    
+    private final Random prng = new Random();
+    
+    /**
+     * A copy of PHListener drop helper code from 5.2.15, modified to generate two objects: the old 5.2.15 HeadRollEvent, and a new 5.3/5.2.16 HeadRollEvent.
+     * This is for the purpose of testing output.
+     * @param event
+     * @param killerEntity
+     * @param type
+     * @param droprateOriginal
+     * @param lootingModifier
+     * @param chargedcreeperModifier
+     * @return an array containing two elements: HeadRollEvent_old (5.2.15 event), HeadRollEvent (5.2.16/5.3 code)
+     */
+     public Object[] MobDeathHelper(Object event, LivingEntity killerEntity, Object type, Double droprateOriginal, Double lootingModifier, Double slimeModifier, Double chargedcreeperModifier) {
+        Double droprate = droprateOriginal * lootingModifier * slimeModifier * chargedcreeperModifier;
+        Double dropchanceRand = prng.nextDouble();
+        Double dropchance = dropchanceRand;
+        Entity entity = null;//event.getEntity();
+        Player killer = killerEntity instanceof Player ? (Player)killerEntity : null;
+        
+        boolean killerAlwaysBeheads = false;
+        /*if (killer != null) {//mob was PK'd
+            if (!killer.hasPermission("playerheads.canbeheadmob")) {
+                return null;//killer does not have permission to behead mobs in any case
+            }
+            killerAlwaysBeheads = killer.hasPermission("playerheads.alwaysbeheadmob");
+            if (killerAlwaysBeheads) {
+                dropchance = 0.0;//alwaysbehead should only modify drop chances
+            }
+        } else {//mob was killed by mob
+            if (plugin.configFile.getBoolean("mobpkonly")) {
+                return;//mobs must only be beheaded by players
+            }
+        }*/
+        boolean headDropSuccess = dropchance < droprate;
+
+         HeadRollEvent_old old_rollEvent = new HeadRollEvent_old(killer, null, killerAlwaysBeheads, lootingModifier, slimeModifier, chargedcreeperModifier, dropchanceRand, dropchance, droprateOriginal, droprate, headDropSuccess);
+         HeadRollEvent new_rollEvent = new HeadRollEvent(killer, null, killerAlwaysBeheads, lootingModifier, slimeModifier, chargedcreeperModifier, dropchanceRand, dropchance, droprateOriginal, droprate, headDropSuccess);
+        
+            Object[] arr = new Object[]{ old_rollEvent, new_rollEvent };
+            return arr;
+
+//plugin.getServer().getPluginManager().callEvent(rollEvent);
+            //if (!rollEvent.succeeded()) {
+            //    return;//allow plugins a chance to modify the success
+            //}
+            
+    }
+}

--- a/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifierTest.java
+++ b/PlayerHeads-base-api/src/test/java/org/shininet/bukkit/playerheads/events/modifiers/DropRateModifierTest.java
@@ -1,0 +1,87 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+ */
+package org.shininet.bukkit.playerheads.events.modifiers;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class DropRateModifierTest {
+    
+    private static final double TOLERANCE = 0.0001;
+    
+    public DropRateModifierTest() {
+    }
+
+    @Test
+    public void testGetLevel() {
+        System.out.println("getLevel");
+        assertEquals(1, new DropRateModifier(DropRateModifierType.ADD_CONSTANT,0.035).getLevel());
+        assertEquals(7, new DropRateModifier(DropRateModifierType.ADD_CONSTANT,0.035,7).getLevel());
+        assertEquals(8, new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.035,8).getLevel());
+    }
+/*
+    @Test
+    public void testGetType() {
+        System.out.println("getType");
+        DropRateModifier instance = null;
+        DropRateModifierType expResult = null;
+        DropRateModifierType result = instance.getType();
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+
+    @Test
+    public void testGetValue() {
+        System.out.println("getValue");
+        DropRateModifier instance = null;
+        double expResult = 0.0;
+        double result = instance.getValue();
+        assertEquals(expResult, result, 0.0);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+    @Test
+    public void testGetAdditiveMultiplierValue() {
+        System.out.println("getAdditiveMultiplierValue");
+        assertEquals(null, new DropRateModifier(DropRateModifierType.ADD_CONSTANT,0.035).getAdditiveMultiplierValue());
+        assertEquals(0.5, (double) new DropRateModifier(DropRateModifierType.MULTIPLY,1.5).getAdditiveMultiplierValue(),TOLERANCE);
+        assertEquals( (-0.5), (double) new DropRateModifier(DropRateModifierType.MULTIPLY,0.5).getAdditiveMultiplierValue(),TOLERANCE);
+        assertEquals(0.02, (double) new DropRateModifier(DropRateModifierType.ADD_MULTIPLE,0.02).getAdditiveMultiplierValue(),TOLERANCE);
+        assertEquals(0.013, (double) new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.013).getAdditiveMultiplierValue(),TOLERANCE);
+        assertEquals( (0.014*3), (double) new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.014,3).getAdditiveMultiplierValue(),TOLERANCE);
+    }
+
+    @Test
+    public void testGetMultiplierValue() {
+        System.out.println("getMultiplierValue");
+        assertEquals(null, new DropRateModifier(DropRateModifierType.ADD_CONSTANT,0.035).getMultiplierValue());
+        assertEquals((Double) 1.5, new DropRateModifier(DropRateModifierType.MULTIPLY,1.5).getMultiplierValue(),TOLERANCE);
+        assertEquals((Double) 0.5, new DropRateModifier(DropRateModifierType.MULTIPLY,0.5).getMultiplierValue(),TOLERANCE);
+        assertEquals((Double) 1.02, new DropRateModifier(DropRateModifierType.ADD_MULTIPLE,0.02).getMultiplierValue(),TOLERANCE);
+        assertEquals((Double) 1.013, new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.013).getMultiplierValue(),TOLERANCE);
+        assertEquals((Double) (1+(0.014*3)), new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.014,3).getMultiplierValue(),TOLERANCE);
+    }
+
+    @Test
+    public void testApply() {
+        double droprate = 0.01;
+        assertEquals((Double) 0.045, (Double) new DropRateModifier(DropRateModifierType.ADD_CONSTANT,0.035).apply(droprate),TOLERANCE);
+        assertEquals((Double) 0.015, (Double) new DropRateModifier(DropRateModifierType.MULTIPLY,1.5).apply(droprate),TOLERANCE);
+        assertEquals((Double) 0.005, (Double) new DropRateModifier(DropRateModifierType.MULTIPLY,0.5).apply(droprate),TOLERANCE);
+        assertEquals((Double) 0.0102, (Double) new DropRateModifier(DropRateModifierType.ADD_MULTIPLE,0.02).apply(droprate),TOLERANCE);
+        assertEquals((Double) 0.01013, (Double) new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.013).apply(droprate),TOLERANCE);
+        assertEquals((Double) ((1+(0.014*3))*0.01),(Double) new DropRateModifier(DropRateModifierType.ADD_MULTIPLE_PER_LEVEL,0.014,3).apply(droprate),TOLERANCE);
+    
+        assertEquals(0.12974400000000003, new DropRateModifier(DropRateModifierType.MULTIPLY,1.5).apply(0.08649600000000002),TOLERANCE);
+    }
+    
+}

--- a/PlayerHeads-core/pom.xml
+++ b/PlayerHeads-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>PlayerHeads</artifactId>
         <groupId>org.shininet.bukkit</groupId>
-        <version>5.2.15-SNAPSHOT</version>
+        <version>5.2.16-SNAPSHOT</version>
     </parent>
     
 
@@ -43,7 +43,7 @@
             <!-- This shouldn't be a dep which is packaging: pom -->
             <groupId>${project.groupId}</groupId>
             <artifactId>PlayerHeads-api</artifactId>
-            <version>5.2.15-SNAPSHOT</version>
+            <version>5.2.16-SNAPSHOT</version>
         </dependency>
         <dependency>
             <!-- This shouldn't be a dep which is packaging: pom -->

--- a/PlayerHeads-crossversion-plugin/dependency-reduced-pom.xml
+++ b/PlayerHeads-crossversion-plugin/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>PlayerHeads</artifactId>
     <groupId>org.shininet.bukkit</groupId>
-    <version>5.2.15-SNAPSHOT</version>
+    <version>5.2.16-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.shininet.bukkit</groupId>

--- a/PlayerHeads-crossversion-plugin/pom.xml
+++ b/PlayerHeads-crossversion-plugin/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>PlayerHeads</artifactId>
         <groupId>org.shininet.bukkit</groupId>
-        <version>5.2.15-SNAPSHOT</version>
+        <version>5.2.16-SNAPSHOT</version>
     </parent>
 
     <organization>
@@ -47,7 +47,7 @@
             <!-- This shouldn't be a dep which is packaging: pom -->
             <groupId>${project.groupId}</groupId>
             <artifactId>PlayerHeads-core</artifactId>
-            <version>5.2.15-SNAPSHOT</version>
+            <version>5.2.16-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.bukkit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.shininet.bukkit</groupId>
     <artifactId>PlayerHeads</artifactId>
     <packaging>pom</packaging>
-    <version>5.2.15-SNAPSHOT</version>
+    <version>5.2.16-SNAPSHOT</version>
     <name>PlayerHeads-5.2</name>
     
     <!-- sub modules -->


### PR DESCRIPTION
Reintroduces droprate modifiers that were coded for the unused 5.3 release.
droprate modifiers are self-contained objects that determine how to change the droprate (with type, rate and level parameters)

headroll event now keeps a list of modifiers (including PH-generated ones), allows getting existing modifiers, changing the list, and adding new modifiers to existing ones - as well as recalculating success from those modifiers.

this reduces work needed to recalculate the success value, and allows better transparency between plugins.|

test code is in place that should guarantee the function between the new and old class are identical

may ease development like in meiskam/PlayerHeads#27